### PR TITLE
Fix/Authentication errors

### DIFF
--- a/src/components/auth/SignedInRouteBlocker.tsx
+++ b/src/components/auth/SignedInRouteBlocker.tsx
@@ -5,7 +5,7 @@ function SignedInRouteBlocker({ children }: { children: JSX.Element }) {
   const { authToken } = useAuth();
 
   if (authToken) {
-    return <Navigate to="/" replace />;
+    return <Navigate to="/search-work" replace />;
   }
 
   return children;

--- a/src/localization/en/en.json
+++ b/src/localization/en/en.json
@@ -26,6 +26,8 @@
   "SignUp": {
     "title": "Sign Up",
     "signUpGoogle": "Sign Up with Google",
+    "successfulSignUp": "You have been successfully registered",
+    "alreadyRegistered": "Email already registered. Please sign in",
     "register": "Register",
     "or": "or",
     "useEmail": "Use your email"
@@ -40,8 +42,10 @@
     "forgotPass": "Forgot your password?",
     "register": "Register now",
     "successLogin": "You have successfully logged in",
-    "errorLogin": "Invalid email and/or password",
-    "errorGoogleOAuth": "Server error, please try again"
+    "errorGoogleOAuth": "Server error, please try again",
+    "404": "Email not found, please Sign Up",
+    "401": "Invalid email and/or password",
+    "409": "Email already registered. Please login with your Google account"
   },
   "CompleteRegistration": {
     "client": "I'm a client, hiring for a project",

--- a/src/localization/en/en.json
+++ b/src/localization/en/en.json
@@ -42,10 +42,14 @@
     "forgotPass": "Forgot your password?",
     "register": "Register now",
     "successLogin": "You have successfully logged in",
-    "errorGoogleOAuth": "Server error, please try again",
-    "404": "Email not found, please Sign Up",
+    "errorGoogleOAuth": "Server error, please try again"
+  },
+  "ServerErrors": {
+    "404": "Email not found, please sign up",
     "401": "Invalid email and/or password",
-    "409": "Email already registered. Please login with your Google account"
+    "409": "Email already registered. Please login with your password or your Google account.",
+    "500": "Server error, please try again",
+    "FETCH_ERROR" : "Server error, please try again"
   },
   "CompleteRegistration": {
     "client": "I'm a client, hiring for a project",

--- a/src/pages/CompleteRegistration/CompleteRegistrationStyles.tsx
+++ b/src/pages/CompleteRegistration/CompleteRegistrationStyles.tsx
@@ -4,7 +4,6 @@ import styled from "styled-components";
 import {
   BLUE,
   DARK_BLUE,
-  // GOOGLE_BTN_BACKGROUND,
   LIGHT_BLUE,
   TEXT_GRAY,
   WHITE,

--- a/src/pages/SignIn/Index.tsx
+++ b/src/pages/SignIn/Index.tsx
@@ -51,7 +51,7 @@ export default function SignIn() {
 
   const errorMessage = (statusCode: string | number) => {
     Modal.error({
-      title: t(`SignIn.${statusCode}`),
+      title: t(`ServerErrors.${statusCode}`),
       centered: true,
       okButtonProps: { danger: true },
     });
@@ -66,6 +66,7 @@ export default function SignIn() {
     if (!isLoading && isError) {
       if ("status" in error!) {
         errorMessage(error.status);
+        return;
       }
     }
     if (!isLoading && isSuccess) {

--- a/src/pages/SignIn/Index.tsx
+++ b/src/pages/SignIn/Index.tsx
@@ -31,7 +31,7 @@ export default function SignIn() {
     resolver: yupResolver(signInSchema),
   });
 
-  const [runSignIn, { isError, isLoading, isSuccess, data }] =
+  const [runSignIn, { isError, isLoading, isSuccess, data, error }] =
     useSignInMutation();
 
   const handleCloseErrorModal = () => {
@@ -41,14 +41,17 @@ export default function SignIn() {
   const success = () => {
     Modal.success({
       title: t("SignIn.successLogin"),
-      onOk: () => navigate(PROFILE_ROUTE),
+      onOk: () => {
+        navigate(PROFILE_ROUTE);
+        signIn(data!);
+      },
       centered: true,
     });
   };
 
-  const error = () => {
+  const errorMessage = (statusCode: string | number) => {
     Modal.error({
-      title: t("SignIn.errorLogin"),
+      title: t(`SignIn.${statusCode}`),
       centered: true,
       okButtonProps: { danger: true },
     });
@@ -61,10 +64,11 @@ export default function SignIn() {
 
   useEffect(() => {
     if (!isLoading && isError) {
-      error();
+      if ("status" in error!) {
+        errorMessage(error.status);
+      }
     }
     if (!isLoading && isSuccess) {
-      signIn(data!);
       success();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/pages/SignUp/Index.tsx
+++ b/src/pages/SignUp/Index.tsx
@@ -26,12 +26,15 @@ export default function SignUp() {
   const { control, handleSubmit } = useForm<SignUpForm>({
     resolver: yupResolver(signUpSchema),
   });
-  const [signUp, { isError, isSuccess, isLoading, data }] = useSignUpMutation();
+  const [signUp, { isError, isSuccess, isLoading, data, error }] =
+    useSignUpMutation();
 
   useEffect(() => {
     if (!isLoading && isError) {
-      toast.error(t("SignUp.alreadyRegistered"));
-      return;
+      if ("status" in error!) {
+        toast.error(t(`ServerErrors.${error.status}`));
+        return;
+      }
     }
     if (!isLoading && isSuccess) {
       Modal.success({

--- a/src/pages/SignUp/Index.tsx
+++ b/src/pages/SignUp/Index.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect } from "react";
-import { Button } from "antd";
+import { Button, Modal } from "antd";
 import { FieldValues, useForm } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { useNavigate } from "react-router-dom";
+import { useTranslation } from "react-i18next";
 import Field from "components/DefaultField/Index";
 import { COMPLETE_REGISTRATION_ROUTE } from "utils/routeConsts";
-import { useTranslation } from "react-i18next";
 import GoogleAuthButton from "components/UI/googleAuthButton/GoogleAuthButton";
 import { useSignUpMutation } from "services/auth/setAuthAPI";
 import { toast } from "react-toastify";
@@ -22,6 +22,7 @@ interface SignUpForm extends FieldValues {
 export default function SignUp() {
   const { signIn } = useAuth();
   const navigate = useNavigate();
+  const { t } = useTranslation();
   const { control, handleSubmit } = useForm<SignUpForm>({
     resolver: yupResolver(signUpSchema),
   });
@@ -29,21 +30,25 @@ export default function SignUp() {
 
   useEffect(() => {
     if (!isLoading && isError) {
-      toast.error("An error ocurred");
+      toast.error(t("SignUp.alreadyRegistered"));
       return;
     }
     if (!isLoading && isSuccess) {
-      toast.success("Successful Sign up");
-      signIn(data!);
+      Modal.success({
+        title: t("SignUp.successfulSignUp"),
+        onOk: () => {
+          navigate(COMPLETE_REGISTRATION_ROUTE);
+          signIn(data!);
+        },
+        centered: true,
+      });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoading]);
 
   async function onSubmit({ email, password }: SignUpForm) {
     await signUp({ email, password });
-    navigate(COMPLETE_REGISTRATION_ROUTE);
   }
-  const { t } = useTranslation();
 
   return (
     <S.Container>


### PR DESCRIPTION
Hi, Luda

In this PR I've made some hot fixes listed below:

- Fixed sign-up redirecting to complete registration even with a server response error.
- If the user tries to sign in without being registered, the frontend will now issue the following error:
![image](https://user-images.githubusercontent.com/61670871/185819069-ad0b6304-0a83-4414-b550-1f33c2352c8e.png)

- If the user tries to log in with an email that has already been registered locally or as a google account, an error will show the following
![image](https://user-images.githubusercontent.com/61670871/185819278-d2cc5eac-f2d9-4084-a579-a8428e3e7459.png)

Any server connection error will issue a "Server error, please try again" error. 

The backend was modified to issue these errors upon signing in or signing up in PR [#11](https://github.com/ZenBit-Tech/HiveIn_be/pull/11)